### PR TITLE
Adds support for desktop.home.nix

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -231,6 +231,7 @@ rec {
         ++ (optionalFile "users/${user}.home.nix")
         ++ (optionalFile "users/default.home.nix")
 
+
         # The users host-specific config, if it exists:
         ++ (notNull gui.${hostnameOrDefault}.desktop (
           desktop: 
@@ -243,6 +244,12 @@ rec {
           requireFile "modules/protocol/${protocol}.home.nix"
         ))
 
+        # If they have a desktop, include modules/desktop/default.home.nix
+        # Using this for things like firefox etc as it makes more sense to be here
+        ++ (notNull gui.${hostnameOrDefault}.desktop (
+          optionalFile "modules/desktop/desktop.home.nix")
+
+        # If they have a theme set, require stylix
         ++ (notNull theme (theme: requireFile "modules/programs/stylix.home.nix"));
     };
 


### PR DESCRIPTION
Adds desktop.home.nix as a optional import if desktop is set for a user, this could be where we install firefox etc.

example usage

```nix
{
  pkgs,
  self,
  ...
}:
{
  imports = [
    "${self}/modules/programs/spotify.home.nix"
  ];

  home.packages = with pkgs; [
    wechat-uos
    obs-studio
    jetbrains.idea-ultimate # Java IDE
    obsidian # Note taking app
    zoom-us
    postman
    brightnessctl # Brightness stuff to desktop?
    firefox
    thunderbird
    vesktop
    grimblast # Screenshot
    slurp # Screenshot
    hyprlock # Lockscreen
    pinta # Image editor
    foot # Backup terminal
    swww # Wallpaper
    zathura # pdf viewer
  ];

  gtk = {
    enable = true;

    # TODO: Hard coded themeing stuff, move to a variable in theme
    iconTheme = {
      package = pkgs.rose-pine-icon-theme;
      name = "rose-pine-moon";
    };
  };
}
```